### PR TITLE
Replaced force casting with protocol composition

### DIFF
--- a/Gomoku/BoardData.swift
+++ b/Gomoku/BoardData.swift
@@ -1,5 +1,5 @@
 class BoardFactoryImpl : BoardFactory {
-    func makeBoard() -> Board {
+    func makeBoard() -> protocol<Board, BoardState> {
         return BoardData()
     }
 }

--- a/Gomoku/Game.swift
+++ b/Gomoku/Game.swift
@@ -1,9 +1,9 @@
 protocol BoardFactory {
-    func makeBoard() -> Board
+    func makeBoard() -> protocol<Board, BoardState>
 }
 
 class Game {
-    let board: Board
+    let board: protocol<Board, BoardState>
     let rules: GomokuRules
     var player = Player.White
     static var boardFactory : BoardFactory!
@@ -27,7 +27,7 @@ class Game {
     }
     
     func getBoard() -> BoardState {
-        return board as! BoardState
+        return board
     }
     
     func getRules() -> GomokuRules {

--- a/GomokuTests/GomokuRulesTest.swift
+++ b/GomokuTests/GomokuRulesTest.swift
@@ -2,14 +2,14 @@ import XCTest
 @testable import Gomoku
 
 class GomokuRulesTest: XCTestCase {
-    var board : Board!
+    var board : protocol<Board, BoardState>!
     var rules : GomokuRules!
     var boardState : BoardState!
     
     override func setUp() {
         Game.boardFactory = BoardFactoryImpl()
         board = Game.boardFactory.makeBoard()
-        boardState = board as! BoardState
+        boardState = board
         rules = GomokuRules()
         super.setUp()
     }
@@ -58,7 +58,7 @@ class GomokuRulesTest: XCTestCase {
     func testFiveConsecutiveInAnyRow_isAWin() {
         for row in 0..<board.getHeight() {
             board = Game.boardFactory.makeBoard()
-            boardState = board as! BoardState
+            boardState = board
             for col in 0..<5 {
                 board.place(col,row, Player.Black)
             }


### PR DESCRIPTION
Force casting can result in runtime crashes, and results in an API
which doesn't fully communicate it's requirements. Protocol
composition can be used to make the requirements obvious.

More info on protocol composition can be [found here](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Protocols.html#//apple_ref/doc/uid/TP40014097-CH25-ID282).
